### PR TITLE
Fix omission of /v4

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -961,7 +961,7 @@ These endpoints allow you interact with your
               + `ProjectImporter`
 
 
-## Remove collaborators [/projects/{projectId}/collaborators/{collaboratorId}]
+## Remove collaborators [/v4/projects/{projectId}/collaborators/{collaboratorId}]
 
 ### Remove collaborator from project [DELETE]
 


### PR DESCRIPTION
in "Remove collaborator from project" route