### PR TITLE
Updated Users v4 from 2.8 to 2.9

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -337,8 +337,8 @@ These endpoints provide information about users in your deployment.
 ### Get a list of users [GET]
 
 **This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
-**Note: The username filter is only supported in 2.9+**<br>
+**Its specification may change in future versions of Domino.**<br>
+**Note: The username filter is only supported in 2.9+**
 
 + Parameters
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -336,8 +336,9 @@ These endpoints provide information about users in your deployment.
 
 ### Get a list of users [GET]
 
-**This is a beta endpoint available in Domino 2.9+**<br>
+**This is a beta endpoint available in Domino 2.8+**<br>
 **Its specification may change in future versions of Domino.**
+**Note: The username filter is only supported in 2.9+**<br>
 
 + Parameters
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -336,7 +336,7 @@ These endpoints provide information about users in your deployment.
 
 ### Get a list of users [GET]
 
-**This is a beta endpoint available in Domino 2.8+**<br>
+**This is a beta endpoint available in Domino 2.9+**<br>
 **Its specification may change in future versions of Domino.**
 
 + Parameters


### PR DESCRIPTION
* The username parameter isn't supported until 2.9, so querying a single user in 2.8 will return all users