### PR TITLE
Update apiary.apib

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -64,7 +64,7 @@ These endpoints allow you to interact with your project's runs and files.
 
         + isDirect: `false` (boolean, required) - A direct command is interpretted as a shell command; Domino doesn't try to infer a program to match your file type.
         + title: `This one should work!` (string) - An optional title for your run.
-        + tier: `gpu` (string) - Identifier of the hardware tier to use.
+        + tier: `gpu` (string) - Identifier of the hardware tier to use. This should be the human-readable name of the hardware tier, such as "Free", "Small", "Medium" etc. 
         + commitId: `1c6e8aa47951e39f9a905f0077af9355c35b712b` (string) - Revision at which to start the run.
         + publishApiEndpoint: `false` (boolean) - __This field will be deprecated in future versions.__ If true, the results of a successful run will be deployed to the project's active API Endpoint, if one exists.
 


### PR DESCRIPTION
Clarified that the "tier" attribute for starting a run should be the human-readable name of the desired hardware tier.