### PR TITLE
correct support link

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
           </a>
         </div>
         <div class="topbar-nav">
-          <a style="text-decoration: none;" href="https://support.dominodatalab.com">
+          <a style="text-decoration: none;" href="https://tickets.dominodatalab.com">
             <p style="font-family: 'Raleway', sans-serif; color: #F4F5F9; font-size: 18; padding-right: 18px;">SUPPORT</p>
           </a>
         </div>


### PR DESCRIPTION
The support link was https://support.dominodatalab.com which redirects to https://docs.dominodatalab.com/en/3.6/ .

The new support site URL appears to be https://tickets.dominodatalab.com