### PR TITLE
[Docs-1290]  Document old public api as deprecated

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3826,7 +3826,7 @@ These endpoints allow you interact with your
 
 ### Create Dataset [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_create_a_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_dataset).**
 
 
 + Parameters

--- a/apiary.apib
+++ b/apiary.apib
@@ -2936,7 +2936,7 @@ These endpoints provide information about users in your deployment.
 
 ### Get current user [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_the_current_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_the_current_user).**
 
 + Request
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3871,7 +3871,7 @@ These endpoints allow you interact with your
 
 ### Remove tag [DELETE]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_remove_a_tag_from_a_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_tag_from_a_dataset).**
 
 + Parameters
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3849,7 +3849,7 @@ These endpoints allow you interact with your
 
 ### Add tag [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_tag_a_snapshot_in_this_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_tag_a_snapshot_in_this_dataset).**
 
 + Parameters
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -4332,7 +4332,7 @@ Deletes an existing notification.
 
 ## Gateway Projects [/gateway/projects{?relationship,showCompleted}]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_projects_visible_to_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_projects_visible_to_user).**
 
 ### list [GET]
 Retrieves projects for the Project List UI, ordered from most to least recently updated

--- a/apiary.apib
+++ b/apiary.apib
@@ -2959,7 +2959,7 @@ your deployment.
 
 ### Get a list of organizations [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_all_organizations_only_accessible_to_admin_users).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_organizations_only_accessible_to_admin_users).**
 
 + Parameters
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -222,6 +222,8 @@ These endpoints allow you to interact with your environments.
 
 ### Get a list of v2 environments [GET]
 
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_environments_visible_to_a_user).**
+
 + Request
 
     + Headers
@@ -2911,8 +2913,7 @@ These endpoints provide information about users in your deployment.
 
 ### Get a list of users [GET]
 
-**This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_users_visible_to_the_current_user).**
 
 + Parameters
 
@@ -2935,8 +2936,7 @@ These endpoints provide information about users in your deployment.
 
 ### Get current user [GET]
 
-**This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_the_current_user).**
 
 + Request
 
@@ -2959,9 +2959,7 @@ your deployment.
 
 ### Get a list of organizations [GET]
 
-**This endpoint requires admin permissions.**<br>
-**This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_organizations_only_accessible_to_admin_users).**
 
 + Parameters
 
@@ -2982,8 +2980,7 @@ your deployment.
 
 ### Create a new organization [POST]
 
-**This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_create_an_organization).**
 
 + Request (application/json)
 
@@ -3021,8 +3018,7 @@ your deployment.
 
 ### Get a list of my organizations [GET]
 
-**This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_the_organizations_for_a_user).**
 
 + Parameters
 
@@ -3043,8 +3039,7 @@ your deployment.
 
 ### Get organization by ID [GET]
 
-**This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_an_organization_by_id.)**
 
 + Parameters
 
@@ -3065,8 +3060,7 @@ your deployment.
 
 ### Change the list of members [PUT]
 
-**This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [ADD endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_add_a_user_to_an_org) and the [DELETE endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_user_from_an_org).**
 
 + Parameters
 
@@ -3094,8 +3088,7 @@ These endpoints allow you interact with your
 
 ### Get a list of user's projects [GET]
 
-**This is a beta endpoint available in Domino 2.9+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_project_by_id).**
 
 + Parameters
 
@@ -3218,8 +3211,8 @@ These endpoints allow you interact with your
 
 ### Copy a project [POST]
 
-**This is a beta endpoint available in Domino 2.9+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_project).**
+
 
 + Parameters
 
@@ -3482,8 +3475,7 @@ These endpoints allow you interact with your
 
 ### Add collaborator to project [POST]
 
-**This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_add_a_collaborator_to_this_project).**
 
 + Parameters
 
@@ -3529,8 +3521,7 @@ These endpoints allow you interact with your
 
 ### Remove collaborator from project [DELETE]
 
-**This is a beta endpoint available in Domino 2.8+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_collaborator_from_project).**
 
 + Parameters
 
@@ -3560,7 +3551,7 @@ These endpoints allow you interact with your
 
 ### Get project's Git repositories [GET]
 
-**This endpoint is available in Domino 3.4+**<br>
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_imported_git_repositories_in_this_project).**
 
 + Parameters
 
@@ -3579,7 +3570,7 @@ These endpoints allow you interact with your
 
 ### Add Git repository to project [POST]
 
-**This endpoint is available in Domino 3.4+**<br>
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_add_an_imported_git_repository_to_this_project).**
 
 + Parameters
 
@@ -3633,7 +3624,7 @@ These endpoints allow you interact with your
 
 ### Remove Git repository [DELETE]
 
-**This endpoint is available in Domino 3.4+**<br>
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_remove_an_imported_repository_from_project).**
 
 + Parameters
 
@@ -3657,8 +3648,6 @@ These endpoints allow you interact with your
 
 ### Get a list of Datasets [GET]
 
-**This is a beta endpoint available in Domino 3.6+**<br>
-**Its specification may change in future versions of Domino.**
 
 + Parameters
 
@@ -3676,8 +3665,7 @@ These endpoints allow you interact with your
 
 ### Create a Dataset [POST]
 
-**This is a beta endpoint available in Domino 3.6+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_datasets_visible_to_user).**
 
 + Request (application/json)
 
@@ -3696,8 +3684,7 @@ These endpoints allow you interact with your
 
 ### Get Dataset details [GET]
 
-**This is a beta endpoint available in Domino 3.6+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_dataset_by_id).**
 
 + Parameters
 
@@ -3715,8 +3702,7 @@ These endpoints allow you interact with your
 
 ### Update Dataset details [PATCH]
 
-**This is a beta endpoint available in Domino 3.6+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_update_dataset_metadata).**
 
 + Parameters
 
@@ -3736,9 +3722,7 @@ These endpoints allow you interact with your
 
 ### Delete Dataset [DELETE]
 
-**Note: Archive Dataset has been changed to admin only operation Delete Dataset starting Domino 4.5**<br>
-**This is a beta endpoint available in Domino 4.5+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_delete_dataset).**
 
 + Parameters
 
@@ -3761,8 +3745,7 @@ These endpoints allow you interact with your
 
 ### Get Snapshot details [GET]
 
-**This is a beta endpoint available in Domino 3.6+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_snapshot).**
 
 + Parameters
 
@@ -3824,8 +3807,7 @@ These endpoints allow you interact with your
 
 ### Create Snapshot [POST]
 
-**This is a beta endpoint available in Domino 4.5+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation]( https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_snapshot).**
 
 + Request
 
@@ -3844,8 +3826,8 @@ These endpoints allow you interact with your
 
 ### Create Dataset [POST]
 
-**This is a beta endpoint available in Domino 4.5+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_dataset).**
+
 
 + Parameters
 
@@ -3867,8 +3849,7 @@ These endpoints allow you interact with your
 
 ### Add tag [POST]
 
-**This is a beta endpoint available in Domino 3.6+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_tag_a_snapshot_in_this_dataset).**
 
 + Parameters
 
@@ -3890,8 +3871,7 @@ These endpoints allow you interact with your
 
 ### Remove tag [DELETE]
 
-**This is a beta endpoint available in Domino 3.6+**<br>
-**Its specification may change in future versions of Domino.**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_tag_from_a_dataset).**
 
 + Parameters
 
@@ -4351,6 +4331,8 @@ Deletes an existing notification.
 # Group Gateway
 
 ## Gateway Projects [/gateway/projects{?relationship,showCompleted}]
+
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_projects_visible_to_user).**
 
 ### list [GET]
 Retrieves projects for the Project List UI, ordered from most to least recently updated

--- a/apiary.apib
+++ b/apiary.apib
@@ -2913,7 +2913,7 @@ These endpoints provide information about users in your deployment.
 
 ### Get a list of users [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_all_users_visible_to_the_current_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_users_visible_to_the_current_user).**
 
 + Parameters
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -222,7 +222,7 @@ These endpoints allow you to interact with your environments.
 
 ### Get a list of v2 environments [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_environments_visible_to_a_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_environments_visible_to_a_user).**
 
 + Request
 
@@ -2913,7 +2913,7 @@ These endpoints provide information about users in your deployment.
 
 ### Get a list of users [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_users_visible_to_the_current_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_users_visible_to_the_current_user).**
 
 + Parameters
 
@@ -2936,7 +2936,7 @@ These endpoints provide information about users in your deployment.
 
 ### Get current user [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_the_current_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_the_current_user).**
 
 + Request
 
@@ -2959,7 +2959,7 @@ your deployment.
 
 ### Get a list of organizations [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_organizations_only_accessible_to_admin_users).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_organizations_only_accessible_to_admin_users).**
 
 + Parameters
 
@@ -2980,7 +2980,7 @@ your deployment.
 
 ### Create a new organization [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_create_an_organization).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_an_organization).**
 
 + Request (application/json)
 
@@ -3018,7 +3018,7 @@ your deployment.
 
 ### Get a list of my organizations [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_the_organizations_for_a_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_the_organizations_for_a_user).**
 
 + Parameters
 
@@ -3039,7 +3039,7 @@ your deployment.
 
 ### Get organization by ID [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_an_organization_by_id.)**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_an_organization_by_id.)**
 
 + Parameters
 
@@ -3060,7 +3060,7 @@ your deployment.
 
 ### Change the list of members [PUT]
 
-**This endpoint is deprecated. For more information, see the [ADD endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_add_a_user_to_an_org) and the [DELETE endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_user_from_an_org).**
+**This endpoint is deprecated. For more information, see the [ADD endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_add_a_user_to_an_org) and the [DELETE endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_user_from_an_org).**
 
 + Parameters
 
@@ -3088,7 +3088,7 @@ These endpoints allow you interact with your
 
 ### Get a list of user's projects [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_project_by_id).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_project_by_id).**
 
 + Parameters
 
@@ -3211,7 +3211,7 @@ These endpoints allow you interact with your
 
 ### Copy a project [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_project).**
 
 
 + Parameters
@@ -3475,7 +3475,7 @@ These endpoints allow you interact with your
 
 ### Add collaborator to project [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_add_a_collaborator_to_this_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_add_a_collaborator_to_this_project).**
 
 + Parameters
 
@@ -3521,7 +3521,7 @@ These endpoints allow you interact with your
 
 ### Remove collaborator from project [DELETE]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_collaborator_from_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_collaborator_from_project).**
 
 + Parameters
 
@@ -3551,7 +3551,7 @@ These endpoints allow you interact with your
 
 ### Get project's Git repositories [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_imported_git_repositories_in_this_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_imported_git_repositories_in_this_project).**
 
 + Parameters
 
@@ -3570,7 +3570,7 @@ These endpoints allow you interact with your
 
 ### Add Git repository to project [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_add_an_imported_git_repository_to_this_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_add_an_imported_git_repository_to_this_project).**
 
 + Parameters
 
@@ -3624,7 +3624,7 @@ These endpoints allow you interact with your
 
 ### Remove Git repository [DELETE]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_remove_an_imported_repository_from_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_remove_an_imported_repository_from_project).**
 
 + Parameters
 
@@ -3665,7 +3665,7 @@ These endpoints allow you interact with your
 
 ### Create a Dataset [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_datasets_visible_to_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_datasets_visible_to_user).**
 
 + Request (application/json)
 
@@ -3684,7 +3684,7 @@ These endpoints allow you interact with your
 
 ### Get Dataset details [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_dataset_by_id).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_dataset_by_id).**
 
 + Parameters
 
@@ -3702,7 +3702,7 @@ These endpoints allow you interact with your
 
 ### Update Dataset details [PATCH]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_update_dataset_metadata).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_update_dataset_metadata).**
 
 + Parameters
 
@@ -3722,7 +3722,7 @@ These endpoints allow you interact with your
 
 ### Delete Dataset [DELETE]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_delete_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_delete_dataset).**
 
 + Parameters
 
@@ -3745,7 +3745,7 @@ These endpoints allow you interact with your
 
 ### Get Snapshot details [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_snapshot).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_snapshot).**
 
 + Parameters
 
@@ -3807,7 +3807,7 @@ These endpoints allow you interact with your
 
 ### Create Snapshot [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation]( https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_snapshot).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_snapshot).**
 
 + Request
 
@@ -3826,7 +3826,7 @@ These endpoints allow you interact with your
 
 ### Create Dataset [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_dataset).**
 
 
 + Parameters
@@ -3849,7 +3849,7 @@ These endpoints allow you interact with your
 
 ### Add tag [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_tag_a_snapshot_in_this_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_tag_a_snapshot_in_this_dataset).**
 
 + Parameters
 
@@ -3871,7 +3871,7 @@ These endpoints allow you interact with your
 
 ### Remove tag [DELETE]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_tag_from_a_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_tag_from_a_dataset).**
 
 + Parameters
 
@@ -4332,7 +4332,7 @@ Deletes an existing notification.
 
 ## Gateway Projects [/gateway/projects{?relationship,showCompleted}]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_projects_visible_to_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_projects_visible_to_user).**
 
 ### list [GET]
 Retrieves projects for the Project List UI, ordered from most to least recently updated

--- a/apiary.apib
+++ b/apiary.apib
@@ -2980,7 +2980,7 @@ your deployment.
 
 ### Create a new organization [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_create_an_organization).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_an_organization).**
 
 + Request (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3088,7 +3088,7 @@ These endpoints allow you interact with your
 
 ### Get a list of user's projects [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_project_by_id).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://520releasepreview.gatsbyjs.io/en/latest/api_guide/8c929e/domino-public-apis/#_get_projects_visible_to_user).**
 
 + Parameters
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -222,7 +222,7 @@ These endpoints allow you to interact with your environments.
 
 ### Get a list of v2 environments [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_environments_visible_to_a_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_environments_visible_to_a_user).**
 
 + Request
 
@@ -2913,7 +2913,7 @@ These endpoints provide information about users in your deployment.
 
 ### Get a list of users [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_users_visible_to_the_current_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_all_users_visible_to_the_current_user).**
 
 + Parameters
 
@@ -2936,7 +2936,7 @@ These endpoints provide information about users in your deployment.
 
 ### Get current user [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_the_current_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_the_current_user).**
 
 + Request
 
@@ -2959,7 +2959,7 @@ your deployment.
 
 ### Get a list of organizations [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_organizations_only_accessible_to_admin_users).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_all_organizations_only_accessible_to_admin_users).**
 
 + Parameters
 
@@ -2980,7 +2980,7 @@ your deployment.
 
 ### Create a new organization [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_an_organization).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_create_an_organization).**
 
 + Request (application/json)
 
@@ -3018,7 +3018,7 @@ your deployment.
 
 ### Get a list of my organizations [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_the_organizations_for_a_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_the_organizations_for_a_user).**
 
 + Parameters
 
@@ -3039,7 +3039,7 @@ your deployment.
 
 ### Get organization by ID [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_an_organization_by_id.)**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_an_organization_by_id.)**
 
 + Parameters
 
@@ -3060,7 +3060,7 @@ your deployment.
 
 ### Change the list of members [PUT]
 
-**This endpoint is deprecated. For more information, see the [ADD endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_add_a_user_to_an_org) and the [DELETE endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_user_from_an_org).**
+**This endpoint is deprecated. For more information, see the [ADD endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_add_a_user_to_an_org) and the [DELETE endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_remove_a_user_from_an_org).**
 
 + Parameters
 
@@ -3088,7 +3088,7 @@ These endpoints allow you interact with your
 
 ### Get a list of user's projects [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_project_by_id).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_project_by_id).**
 
 + Parameters
 
@@ -3211,7 +3211,7 @@ These endpoints allow you interact with your
 
 ### Copy a project [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_create_a_project).**
 
 
 + Parameters
@@ -3475,7 +3475,7 @@ These endpoints allow you interact with your
 
 ### Add collaborator to project [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_add_a_collaborator_to_this_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_add_a_collaborator_to_this_project).**
 
 + Parameters
 
@@ -3521,7 +3521,7 @@ These endpoints allow you interact with your
 
 ### Remove collaborator from project [DELETE]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_collaborator_from_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_remove_a_collaborator_from_project).**
 
 + Parameters
 
@@ -3551,7 +3551,7 @@ These endpoints allow you interact with your
 
 ### Get project's Git repositories [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_all_imported_git_repositories_in_this_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_all_imported_git_repositories_in_this_project).**
 
 + Parameters
 
@@ -3570,7 +3570,7 @@ These endpoints allow you interact with your
 
 ### Add Git repository to project [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_add_an_imported_git_repository_to_this_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_add_an_imported_git_repository_to_this_project).**
 
 + Parameters
 
@@ -3624,7 +3624,7 @@ These endpoints allow you interact with your
 
 ### Remove Git repository [DELETE]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_remove_an_imported_repository_from_project).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_remove_an_imported_repository_from_project).**
 
 + Parameters
 
@@ -3665,7 +3665,7 @@ These endpoints allow you interact with your
 
 ### Create a Dataset [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_datasets_visible_to_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_datasets_visible_to_user).**
 
 + Request (application/json)
 
@@ -3684,7 +3684,7 @@ These endpoints allow you interact with your
 
 ### Get Dataset details [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_dataset_by_id).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_dataset_by_id).**
 
 + Parameters
 
@@ -3702,7 +3702,7 @@ These endpoints allow you interact with your
 
 ### Update Dataset details [PATCH]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_update_dataset_metadata).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_update_dataset_metadata).**
 
 + Parameters
 
@@ -3722,7 +3722,7 @@ These endpoints allow you interact with your
 
 ### Delete Dataset [DELETE]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_delete_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_delete_dataset).**
 
 + Parameters
 
@@ -3745,7 +3745,7 @@ These endpoints allow you interact with your
 
 ### Get Snapshot details [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_snapshot).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_snapshot).**
 
 + Parameters
 
@@ -3807,7 +3807,7 @@ These endpoints allow you interact with your
 
 ### Create Snapshot [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_snapshot).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_create_a_snapshot).**
 
 + Request
 
@@ -3826,7 +3826,7 @@ These endpoints allow you interact with your
 
 ### Create Dataset [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_create_a_dataset).**
 
 
 + Parameters
@@ -3849,7 +3849,7 @@ These endpoints allow you interact with your
 
 ### Add tag [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_tag_a_snapshot_in_this_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_tag_a_snapshot_in_this_dataset).**
 
 + Parameters
 
@@ -3871,7 +3871,7 @@ These endpoints allow you interact with your
 
 ### Remove tag [DELETE]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_remove_a_tag_from_a_dataset).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_remove_a_tag_from_a_dataset).**
 
 + Parameters
 
@@ -4332,7 +4332,7 @@ Deletes an existing notification.
 
 ## Gateway Projects [/gateway/projects{?relationship,showCompleted}]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_projects_visible_to_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_projects_visible_to_user).**
 
 ### list [GET]
 Retrieves projects for the Project List UI, ordered from most to least recently updated

--- a/apiary.apib
+++ b/apiary.apib
@@ -3807,7 +3807,7 @@ These endpoints allow you interact with your
 
 ### Create Snapshot [POST]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_create_a_snapshot).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_create_a_snapshot).**
 
 + Request
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -222,7 +222,7 @@ These endpoints allow you to interact with your environments.
 
 ### Get a list of v2 environments [GET]
 
-**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/5.2/api_guide/8c929e/domino-public-apis/#_get_environments_visible_to_a_user).**
+**This endpoint is deprecated. For more information, see the [current endpoint documentation](https://docs.dominodatalab.com/en/latest/api_guide/8c929e/domino-public-apis/#_get_environments_visible_to_a_user).**
 
 + Request
 


### PR DESCRIPTION
Jira:
https://dominodatalab.atlassian.net/browse/DOCS-1290

Deprecated the old endpoints and provided links to new public endpoints.