### PR TITLE
DOCS-1329 - Add a banner with a link to the new API guide

### DIFF
--- a/header.css
+++ b/header.css
@@ -12,10 +12,7 @@
   padding-bottom: calc(10px * 2);
   -webkit-box-align: center;
       -ms-flex-align: center;
-          align-items: center;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+          align-items:center;
 }
 .topbar__col {
   display: -webkit-box;
@@ -32,4 +29,39 @@
 }
 .topbar__col--nav {
   width: 100%;
+}
+.topbar-nav-right {
+  width: 100%;
+  text-align: right;
+}
+
+#pointer {
+  width: 400px;
+  height: 40px;
+  position:absolute;
+  right: 10px;
+  top: 12px;
+  background: white;
+}
+#pointer:after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 0;
+  border-left: 20px solid #2D71C7;
+  border-top: 20px solid transparent;
+  border-bottom: 20px solid transparent;
+}
+#pointer:before {
+  content: "";
+  position: absolute;
+  right: -20px;
+  bottom: 0;
+  width: 0;
+  height: 0;
+  border-left: 20px solid #2D71C7;
+  border-top: 20px solid transparent;
+  border-bottom: 20px solid transparent;
 }

--- a/index.html
+++ b/index.html
@@ -29,6 +29,14 @@
             <p style="font-family: 'Raleway', sans-serif; color: #F4F5F9; font-size: 18; padding-right: 18px;">SUPPORT</p>
           </a>
         </div>
+        <div class="topbar-nav-right">
+          <div id="pointer">
+            <p style="font-family: 'Raleway', sans-serif; color: #2D71C7; font-size: 14; padding-right: 10px; position:fixed; top: 2px; right: 10px;">New public APIs are available with Domino 5.2 and up.<br/>See the 
+              <a href="https://docs.dominodatalab.com/en/latest/api_guide/f35c19/domino-apis/">
+                Domino API Guide</a>.
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   </header>


### PR DESCRIPTION
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/89212537/189250883-7b6b1298-dea0-46cc-b3f4-5cd941f83be9.png">
